### PR TITLE
12 store profile UI

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KioSpeak Admin - Menu Manager</title>
+  <style>
+    :root {
+      --primary: #2196f3;
+      --danger: #f44336;
+      --success: #4caf50;
+      --bg: #f5f5f5;
+      --card-bg: #fff;
+      --border: #ddd;
+    }
+
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: var(--bg);
+      display: flex;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    /* Layout */
+    .admin-container {
+      display: flex;
+      width: 100%;
+      height: 100%;
+    }
+
+    .sidebar {
+      width: 250px;
+      background: #fff;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .editor-panel {
+      width: 350px;
+      background: #fff;
+      border-left: 1px solid var(--border);
+      overflow-y: auto;
+      padding: 1rem;
+      display: none;
+    }
+
+    .editor-panel.open {
+      display: block;
+    }
+
+    /* Sidebar Elements */
+    .sidebar-header {
+      padding: 1rem;
+      border-bottom: 1px solid var(--border);
+      font-weight: bold;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .category-list {
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    .category-item {
+      padding: 10px 1rem;
+      cursor: pointer;
+      border-bottom: 1px solid #eee;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .category-item:hover {
+      background: #f0f0f0;
+    }
+
+    .category-item.active {
+      background: #e3f2fd;
+      color: var(--primary);
+      font-weight: bold;
+    }
+
+    /* Main Area */
+    .main-header {
+      padding: 1rem;
+      background: #fff;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .item-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+      align-content: start;
+    }
+
+    .menu-item-card {
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+      cursor: pointer;
+      transition: 0.2s;
+      position: relative;
+    }
+
+    .menu-item-card:hover {
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      border-color: var(--primary);
+    }
+
+    .menu-item-card h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1rem;
+    }
+
+    .price {
+      color: var(--primary);
+      font-weight: bold;
+    }
+
+    /* Buttons */
+    .btn {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: white;
+    }
+
+    .btn-danger {
+      background: var(--danger);
+      color: white;
+    }
+
+    .btn-success {
+      background: var(--success);
+      color: white;
+    }
+
+    .btn-sm {
+      padding: 2px 6px;
+      font-size: 12px;
+    }
+
+    /* Forms */
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    .form-group label {
+      display: block;
+      margin-bottom: 5px;
+      font-weight: bold;
+      font-size: 0.9rem;
+    }
+
+    .form-control {
+      width: 100%;
+      padding: 8px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+
+    .checkbox-group {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    /* Commit Bar */
+    .commit-bar {
+      padding: 1rem;
+      background: #333;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .staged-badge {
+      background: var(--success);
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 12px;
+      margin-left: 10px;
+      display: none;
+    }
+
+    /* Option Group Editor in Panel */
+    .option-group-editor {
+      border: 1px solid #eee;
+      padding: 10px;
+      margin-bottom: 10px;
+      border-radius: 4px;
+      background: #fafafa;
+    }
+
+    .option-item-row {
+      display: flex;
+      gap: 5px;
+      margin-top: 5px;
+      align-items: center;
+    }
+
+    /* Timeline / History */
+    .timeline {
+      padding: 2rem;
+      position: relative;
+    }
+
+    .timeline::before {
+      content: '';
+      position: absolute;
+      left: 30px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: #ddd;
+    }
+
+    .timeline-item {
+      position: relative;
+      padding-left: 50px;
+      margin-bottom: 2rem;
+    }
+
+    .timeline-marker {
+      position: absolute;
+      left: 24px;
+      top: 0;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: var(--primary);
+      border: 3px solid #fff;
+      box-shadow: 0 0 0 2px var(--border);
+    }
+
+    .timeline-content {
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
+    .timeline-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.5rem;
+    }
+
+    .commit-msg {
+      font-weight: bold;
+      font-size: 1.1rem;
+      margin: 0;
+    }
+
+    .commit-meta {
+      color: #666;
+      font-size: 0.8rem;
+      margin-top: 0.5rem;
+      display: flex;
+      gap: 1rem;
+    }
+
+    .btn-rollback {
+      background: #ff9800;
+      color: white;
+      border: none;
+      padding: 5px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+
+    .btn-rollback:hover {
+      background: #f57c00;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="app" class="admin-container"></div>
+  <script type="module" src="/src/admin.ts"></script>
+</body>
+
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^1.30.0",
+        "@types/crypto-js": "^4.2.2",
+        "crypto-js": "^4.2.0",
         "eventemitter3": "^5.0.1",
         "face-api.js": "^0.22.2",
         "fast-json-patch": "^3.1.1",
@@ -175,7 +177,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -219,7 +220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1064,6 +1064,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1084,7 +1090,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1375,6 +1380,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -1880,7 +1891,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -2121,7 +2131,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2581,7 +2590,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@google/genai": "^1.30.0",
+    "@types/crypto-js": "^4.2.2",
+    "crypto-js": "^4.2.0",
     "eventemitter3": "^5.0.1",
     "face-api.js": "^0.22.2",
     "fast-json-patch": "^3.1.1",

--- a/public/profile/coffee_profile.json
+++ b/public/profile/coffee_profile.json
@@ -1,0 +1,540 @@
+{
+  "profileId": "default-profile",
+  "version": "1.0.0",
+  "store": {
+    "id": "store-001",
+    "name": "KioSpeak 커피",
+    "address": "서울시 강남구",
+    "phone": "02-1234-5678",
+    "currency": "KRW",
+    "taxRate": 10,
+    "businessHours": {
+      "monday": {
+        "open": "09:00",
+        "close": "22:00"
+      },
+      "tuesday": {
+        "open": "09:00",
+        "close": "22:00"
+      },
+      "wednesday": {
+        "open": "09:00",
+        "close": "22:00"
+      },
+      "thursday": {
+        "open": "09:00",
+        "close": "22:00"
+      },
+      "friday": {
+        "open": "09:00",
+        "close": "23:00"
+      },
+      "saturday": {
+        "open": "10:00",
+        "close": "23:00"
+      },
+      "sunday": {
+        "open": "10:00",
+        "close": "21:00"
+      }
+    }
+  },
+  "menu": {
+    "categories": [
+      {
+        "id": "blend_coffee",
+        "name": "블렌드 커피",
+        "displayOrder": 1,
+        "commonOptionGroups": [
+          {
+            "id": "bean",
+            "name": "원두 선택",
+            "required": true,
+            "multiSelect": false,
+            "items": [
+              {
+                "id": "default",
+                "name": "너티",
+                "price": 0,
+                "available": true
+              },
+              {
+                "id": "special",
+                "name": "스페셜 티",
+                "price": 500,
+                "available": true
+              },
+              {
+                "id": "decaf",
+                "name": "디카페인",
+                "price": 500,
+                "available": true
+              }
+            ]
+          },
+          {
+            "id": "temperature",
+            "name": "HOT or ICE",
+            "required": true,
+            "multiSelect": false,
+            "items": [
+              {
+                "id": "hot",
+                "name": "HOT",
+                "price": 0,
+                "available": true
+              },
+              {
+                "id": "ice",
+                "name": "ICE",
+                "price": 0,
+                "available": true
+              }
+            ]
+          },
+          {
+            "id": "size",
+            "name": "사이즈",
+            "required": true,
+            "multiSelect": false,
+            "items": [
+              {
+                "id": "small",
+                "name": "S",
+                "price": 0,
+                "available": true
+              },
+              {
+                "id": "medium",
+                "name": "M",
+                "price": 500,
+                "available": true
+              },
+              {
+                "id": "large",
+                "name": "L",
+                "price": 1000,
+                "available": true
+              }
+            ]
+          },
+          {
+            "id": "shot-add",
+            "name": "샷추가",
+            "required": false,
+            "multiSelect": true,
+            "items": [
+              {
+                "id": "espresso",
+                "name": "에스프레소",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "extra-espresso-citrus",
+                "name": "추가_에스프레소(시트러스)",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "decaf-shot",
+                "name": "샷추가__(디카페인)",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "chocolate-syrup",
+                "name": "초콜릿시럽",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "oat-milk",
+                "name": "오트우유변경",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "hazelnut-syrup",
+                "name": "헤이즐넛시럽",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "caramel-syrup",
+                "name": "카라멜시럽",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "vanilla-syrup",
+                "name": "바닐라시럽",
+                "price": 600,
+                "available": true
+              },
+              {
+                "id": "whipped-cream",
+                "name": "휘핑크림",
+                "price": 600,
+                "available": true
+              }
+            ]
+          },
+          {
+            "id": "half-shot",
+            "name": "반샷",
+            "required": false,
+            "multiSelect": true,
+            "items": [
+              {
+                "id": "half-shot",
+                "name": "½샷(반샷)",
+                "price": 0,
+                "available": true
+              }
+            ]
+          },
+          {
+            "id": "milk-amount",
+            "name": "우유 양 선택",
+            "required": false,
+            "multiSelect": false,
+            "items": [
+              {
+                "id": "less-milk",
+                "name": "우유 적게",
+                "price": 0,
+                "available": true
+              },
+              {
+                "id": "more-milk",
+                "name": "우유 많이",
+                "price": 0,
+                "available": true
+              }
+            ]
+          }
+        ],
+        "items": [
+          {
+            "id": "milky-vanilla-angel-espresso",
+            "name": "밀키바닐라엔젤(에스프레소)",
+            "price": 6400,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312103605569_1.png",
+            "available": true,
+            "optionGroups": [
+              {
+                "id": "sinamon-option",
+                "name": "시나몬",
+                "required": false,
+                "multiSelect": true,
+                "items": [
+                  {
+                    "id": "sinamon",
+                    "name": "시나몬 올리기",
+                    "price": 0,
+                    "available": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "americano",
+            "name": "아메리카노",
+            "price": 5000,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312105716967_0.png",
+            "available": true,
+            "optionGroups": [
+              {
+                "id": "water-amount",
+                "name": "물 양 선택",
+                "required": false,
+                "multiSelect": false,
+                "items": [
+                  {
+                    "id": "less-water",
+                    "name": "물 적게",
+                    "price": 0,
+                    "available": true
+                  },
+                  {
+                    "id": "more-water",
+                    "name": "물 많이",
+                    "price": 0,
+                    "available": true
+                  }
+                ]
+              }
+            ],
+            "excludeOptions": [
+              "milk-amount",
+              "shot-add.oat-milk",
+              "shot-add.whipped-cream"
+            ]
+          },
+          {
+            "id": "cafe-latte",
+            "name": "카페라떼",
+            "price": 5600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/2025031211155370_1.png",
+            "available": true
+          },
+          {
+            "id": "cafe-mocha",
+            "name": "카페모카",
+            "price": 5900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/2025031211285377_0.png",
+            "available": true
+          },
+          {
+            "id": "vanilla-latte",
+            "name": "바닐라라떼",
+            "price": 5900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312113937131_5.png",
+            "available": true
+          },
+          {
+            "id": "cappuccino",
+            "name": "카푸치노",
+            "price": 5600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312115731950_4.png",
+            "available": true
+          },
+          {
+            "id": "caramel-macchiato",
+            "name": "카라멜마끼아또",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312130536672_1.png",
+            "available": true
+          },
+          {
+            "id": "dolce-latte",
+            "name": "돌체라떼",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312131736389_6.png",
+            "available": true
+          },
+          {
+            "id": "cafe-oat",
+            "name": "카페오트",
+            "price": 6000,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312132549179_3.png",
+            "available": true
+          },
+          {
+            "id": "espresso",
+            "name": "에스프레소",
+            "price": 5000,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2022/10/13/20221013090245847_8.png",
+            "available": true,
+            "excludeOptions": [
+              "size",
+              "temperature",
+              "shot-add",
+              "milk-amount"
+            ]
+          },
+          {
+            "id": "americhino-crush",
+            "name": "아메리치노크러쉬",
+            "price": 5900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/08/09/20240809182759475_6.png",
+            "available": true
+          },
+          {
+            "id": "americhino-milky-crush",
+            "name": "아메리치노 밀키크러쉬(특화)",
+            "price": 6800,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/07/02/20250702191400396_1.png",
+            "available": true
+          },
+          {
+            "id": "americhino-breeze",
+            "name": "아메리치노 브리즈",
+            "price": 6800,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/08/09/2024080918282121_0.png",
+            "available": true
+          }
+        ]
+      },
+      {
+        "id": "drink",
+        "name": "드링크",
+        "displayOrder": 2,
+        "items": [
+          {
+            "id": "real-apple-juice",
+            "name": "리얼 사과주스",
+            "price": 7000,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/02/09/20230209190007184_3.png",
+            "available": true
+          },
+          {
+            "id": "real-apple-carrot-juice",
+            "name": "리얼 사과&당근주스",
+            "price": 7000,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/02/09/20230209185954287_9.png",
+            "available": true
+          },
+          {
+            "id": "real-cherry-tomato-juice",
+            "name": "리얼 방울토마토주스",
+            "price": 6500,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/02/09/20230209190022227_7.png",
+            "available": true
+          },
+          {
+            "id": "real-peach-juice",
+            "name": "리얼 복숭아주스",
+            "price": 6500,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2022/08/18/20220818104433333_9.png",
+            "available": true
+          },
+          {
+            "id": "red-grapefruit-sparkling-ade",
+            "name": "레드자몽스파클링에이드",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/03/30/20230330085458408_1.png",
+            "available": true
+          },
+          {
+            "id": "strawberry-sparkling-ade",
+            "name": "딸기스파클링에이드",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/03/30/20230330084456961_2.png",
+            "available": true
+          },
+          {
+            "id": "shine-muscat-sparkling-ade",
+            "name": "샤인머스캣 스파클링 에이드",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2023/03/30/20230330084649738_8.png",
+            "available": true
+          },
+          {
+            "id": "strawberry-latte",
+            "name": "딸기라떼",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2022/04/29/20220429103513806_3.png",
+            "available": true
+          },
+          {
+            "id": "mint-choco-latte",
+            "name": "민트초코라떼",
+            "price": 5900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/10/30/20241030115307881_1.jpg",
+            "available": true
+          },
+          {
+            "id": "chocolate-latte",
+            "name": "초콜릿라떼",
+            "price": 5900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2021/10/13/20211013174831809_3.png",
+            "available": true
+          },
+          {
+            "id": "earl-grey-milk-tea",
+            "name": "얼그레이 밀크티",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2022/12/07/20221207182940170_5.png",
+            "available": true
+          },
+          {
+            "id": "jeju-matcha-latte",
+            "name": "제주말차라떼",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/10/22/20241022092822985_5.png",
+            "available": true
+          },
+          {
+            "id": "purple-sweet-potato-latte",
+            "name": "자색고구마라떼",
+            "price": 6300,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2022/01/17/20220117164141350_8.jpg",
+            "available": true
+          }
+        ]
+      },
+      {
+        "id": "cake",
+        "name": "케이크",
+        "displayOrder": 3,
+        "items": [
+          {
+            "id": "mango-vanilla-cake",
+            "name": "망고바닐라케이크",
+            "price": 7600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/08/28/20250828161049988_3.png",
+            "available": true
+          },
+          {
+            "id": "strawberry-milk-cake",
+            "name": "스트로베리밀크케이크",
+            "price": 7600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/08/28/20250828161131745_2.png",
+            "available": true
+          },
+          {
+            "id": "chocolate-layer-cake",
+            "name": "초콜릿레이어케이크",
+            "price": 7600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/08/28/20250828161148617_7.png",
+            "available": true
+          },
+          {
+            "id": "hazelnut-cream-cake",
+            "name": "헤이즐넛크림케이크",
+            "price": 7600,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/08/28/20250828161206779_3.png",
+            "available": true
+          },
+          {
+            "id": "strawberry-fruit-cake",
+            "name": "스트로베리 프룻 케이크",
+            "price": 6700,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/06/18/2024061809483652_2.png",
+            "available": true
+          },
+          {
+            "id": "blueberry-buttermilk-triangle",
+            "name": "블루베리 버터밀크 트라이앵글",
+            "price": 6500,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/06/18/2024061809485556_5.png",
+            "available": true
+          },
+          {
+            "id": "premium-apple-pie",
+            "name": "프리미엄 애플파이",
+            "price": 5800,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/06/18/20240618094911875_4.png",
+            "available": true
+          },
+          {
+            "id": "chocolate-crunch-cake",
+            "name": "초콜릿 크런치 케이크",
+            "price": 6900,
+            "imgUrl": "https://img.lotteeatz.com/upload/product/2024/06/18/20240618094935644_1.png",
+            "available": true
+          }
+        ]
+      }
+    ]
+  },
+  "promotions": [],
+  "settings": {
+    "language": "ko",
+    "voiceAssistant": {
+      "enabled": true,
+      "greeting": "안녕하세요! 주문을 도와드릴게요.",
+      "persona": "친절한 키오스크 직원"
+    },
+    "display": {
+      "theme": "light",
+      "fontSize": "medium",
+      "idleTimeout": 60
+    }
+  },
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-12-03T00:00:00.000Z"
+}

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -470,15 +470,19 @@ class AdminUI {
 
   private addNewItem() {
     if (!this.selectedCategoryId) return;
-    this.profileModule.addMenuItem(this.selectedCategoryId, {
-      name: 'New Item',
-      price: 0,
-      description: '',
-      available: true,
-      optionGroups: []
-    });
-    this.renderItems();
-    this.updateStagedStatus();
+    try {
+      this.profileModule.addMenuItem(this.selectedCategoryId, {
+        name: 'New Item',
+        price: 0,
+        description: '',
+        available: true,
+        optionGroups: []
+      });
+      this.renderItems();
+      this.updateStagedStatus();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
   }
 
   private editItem(itemId: string) {
@@ -525,19 +529,23 @@ class AdminUI {
 
     // Handlers
     document.getElementById('btn-save-item')?.addEventListener('click', () => {
-      const name = (document.getElementById('item-name') as HTMLInputElement).value;
-      const price = parseInt((document.getElementById('item-price') as HTMLInputElement).value);
-      const imgUrl = (document.getElementById('item-img') as HTMLInputElement).value;
-      const available = (document.getElementById('item-avail') as HTMLInputElement).checked;
-      const options = this.collectOptionGroupsFromEditor('item-options');
+      try {
+        const name = (document.getElementById('item-name') as HTMLInputElement).value;
+        const price = parseInt((document.getElementById('item-price') as HTMLInputElement).value);
+        const imgUrl = (document.getElementById('item-img') as HTMLInputElement).value;
+        const available = (document.getElementById('item-avail') as HTMLInputElement).checked;
+        const options = this.collectOptionGroupsFromEditor('item-options');
 
-      this.profileModule.updateMenuItem(itemId, {
-        name, price, imgUrl, available, optionGroups: options
-      });
+        this.profileModule.updateMenuItem(itemId, {
+          name, price, imgUrl, available, optionGroups: options
+        });
 
-      this.updateStagedStatus();
-      this.renderItems();
-      this.closeEditor();
+        this.updateStagedStatus();
+        this.renderItems();
+        this.closeEditor();
+      } catch (e) {
+        alert(e instanceof Error ? e.message : String(e));
+      }
     });
 
     document.getElementById('btn-del-item')?.addEventListener('click', () => {

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -252,7 +252,7 @@ class AdminUI {
                 <h2>Commit History</h2>
                 <button class="btn" id="btn-close-history">Close History</button>
             </div>
-            <div class="timeline" id="history-timeline">
+            <div class="timeline" id="history-timeline" style="overflow-y:auto; max-height:calc(100vh - 80px);">
                 <div style="text-align:center; padding:2rem;">Loading history...</div>
             </div>
         `;
@@ -262,7 +262,7 @@ class AdminUI {
     });
 
     try {
-      const history = await this.profileModule.getHistory();
+      const history = await this.profileModule.getHistory(1000); // Fetch up to 1000 commits to show "all"
       const container = document.getElementById('history-timeline');
       if (!container) return;
 

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,0 +1,608 @@
+import { StoreProfileModule } from './modules/store_profile';
+import type {
+  MenuOptionGroup,
+  MenuOptionItem
+} from './modules/store_profile';
+import { v4 as uuidv4 } from 'uuid';
+
+class AdminUI {
+  private container: HTMLElement;
+  private profileModule: StoreProfileModule;
+  private selectedCategoryId: string | null = null;
+
+  constructor(containerId: string) {
+    const el = document.getElementById(containerId);
+    if (!el) throw new Error('Container not found');
+    this.container = el;
+    this.profileModule = new StoreProfileModule();
+  }
+
+  async init() {
+    this.container.innerHTML = '<div style="padding:2rem;">Loading profile...</div>';
+
+    try {
+      await this.profileModule.initialize();
+      this.renderLayout();
+      this.updateStagedStatus();
+    } catch (e) {
+      this.container.innerHTML = `<div style="color:red; padding:2rem;">Error: ${e}</div>`;
+    }
+  }
+
+  private renderLayout() {
+    this.container.innerHTML = `
+            <div class="sidebar">
+                <div class="sidebar-header">
+                    <span>Categories</span>
+                    <div>
+                        <button class="btn btn-sm" id="btn-history" title="History">🕒</button>
+                        <button class="btn btn-sm btn-primary" id="btn-add-cat">+</button>
+                    </div>
+                </div>
+                <div class="category-list" id="category-list"></div>
+                <div class="commit-bar">
+                    <div style="font-size:0.8rem">
+                        Admin Mode
+                        <span class="staged-badge" id="staged-badge">Changes Staged</span>
+                    </div>
+                    <div>
+                        <button class="btn btn-sm btn-success" id="btn-commit">Commit</button>
+                        <button class="btn btn-sm" id="btn-import" style="background:#555; color:white;" title="Import JSON">⬆</button>
+                        <button class="btn btn-sm" id="btn-export" style="background:#555; color:white;" title="Export JSON">⬇</button>
+                        <input type="file" id="file-import" accept=".json" style="display:none">
+                    </div>
+                </div>
+            </div>
+            <div class="main">
+                <div class="main-header">
+                    <h2 id="main-title">Select Category</h2>
+                    <button class="btn btn-primary" id="btn-add-item" style="display:none;">Add Item</button>
+                </div>
+                <div class="item-list" id="item-list"></div>
+            </div>
+            <div class="editor-panel" id="editor-panel"></div>
+        `;
+
+    // Event Listeners
+    document.getElementById('btn-add-cat')?.addEventListener('click', () => this.addNewCategory());
+    document.getElementById('btn-history')?.addEventListener('click', () => this.renderHistory());
+    document.getElementById('btn-add-item')?.addEventListener('click', () => this.addNewItem());
+    document.getElementById('btn-commit')?.addEventListener('click', () => this.handleCommit());
+    document.getElementById('btn-export')?.addEventListener('click', () => this.handleExport());
+
+    // Import Handlers
+    const fileInput = document.getElementById('file-import') as HTMLInputElement;
+    document.getElementById('btn-import')?.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', (e) => this.handleImport(e));
+
+    this.renderCategories();
+  }
+
+  private async handleImport(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+
+    const file = input.files[0];
+    const reader = new FileReader();
+
+    reader.onload = async (e) => {
+      try {
+        const json = e.target?.result as string;
+        this.profileModule.importProfile(json);
+        alert('Profile imported successfully! Changes are staged.');
+        this.updateStagedStatus();
+        this.renderCategories();
+        this.selectedCategoryId = null;
+        const itemsDiv = document.getElementById('item-list');
+        const title = document.getElementById('main-title');
+        const addBtn = document.getElementById('btn-add-item');
+        if (itemsDiv) itemsDiv.innerHTML = '';
+        if (title) title.innerText = 'Menu Manager';
+        if (addBtn) addBtn.style.display = 'none';
+      } catch (err) {
+        alert(`Import failed: ${err}`);
+      }
+      // Reset input so same file can be selected again if needed
+      input.value = '';
+    };
+
+    reader.readAsText(file);
+  }
+
+  private renderCategories() {
+    const list = document.getElementById('category-list');
+    if (!list) return;
+
+    const categories = this.profileModule.getCategories().sort((a, b) => a.displayOrder - b.displayOrder);
+
+    list.innerHTML = categories.map(cat => `
+            <div class="category-item ${this.selectedCategoryId === cat.id ? 'active' : ''}" data-id="${cat.id}">
+                <span>${cat.name}</span>
+                <button class="btn-sm btn-edit-cat" data-id="${cat.id}">⚙️</button>
+            </div>
+        `).join('');
+
+    // Listeners
+    list.querySelectorAll('.category-item').forEach(el => {
+      el.addEventListener('click', (e) => {
+        const target = e.target as HTMLElement;
+        if (!target.classList.contains('btn-edit-cat')) {
+          this.selectCategory(el.getAttribute('data-id')!);
+        }
+      });
+    });
+
+    list.querySelectorAll('.btn-edit-cat').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.editCategory(btn.getAttribute('data-id')!);
+      });
+    });
+  }
+
+  private selectCategory(id: string) {
+    this.selectedCategoryId = id;
+    this.closeEditor();
+    this.renderCategories(); // update active class
+    this.renderItems();
+  }
+
+  private renderItems() {
+    const container = document.getElementById('item-list');
+    const title = document.getElementById('main-title');
+    const addBtn = document.getElementById('btn-add-item');
+
+    if (!container || !title || !addBtn) return;
+
+    if (!this.selectedCategoryId) {
+      container.innerHTML = '<div style="color:#999; text-align:center; padding:2rem;">Select a category</div>';
+      title.innerText = 'Menu Manager';
+      addBtn.style.display = 'none';
+      return;
+    }
+
+    const category = this.profileModule.getCategory(this.selectedCategoryId);
+    if (!category) return;
+
+    title.innerText = category.name;
+    addBtn.style.display = 'block';
+
+    container.innerHTML = category.items.map(item => `
+            <div class="menu-item-card" data-id="${item.id}">
+                <div style="position:absolute; top:5px; right:5px;">
+                    <span class="badge ${item.available ? 'badge-success' : 'badge-danger'}" 
+                          style="width:10px; height:10px; display:inline-block; border-radius:50%; background:${item.available ? '#4caf50' : '#ccc'}"></span>
+                </div>
+                <h3>${item.name}</h3>
+                <div class="price">${item.price.toLocaleString()}원</div>
+                <div style="font-size:0.8rem; color:#666; margin-top:5px;">
+                    Options: ${(item.optionGroups || []).length}
+                </div>
+            </div>
+        `).join('');
+
+    container.querySelectorAll('.menu-item-card').forEach(el => {
+      el.addEventListener('click', () => {
+        this.editItem(el.getAttribute('data-id')!);
+      });
+    });
+  }
+
+  private closeEditor() {
+    const panel = document.getElementById('editor-panel');
+    if (panel) panel.classList.remove('open');
+  }
+
+  // ============ HISTORY VIEW ============ //
+
+  private async renderHistory() {
+    const main = document.querySelector('.main');
+    if (!main) return;
+
+    // Clear existing content and switch view
+    main.innerHTML = `
+            <div class="main-header">
+                <h2>Commit History</h2>
+                <button class="btn" id="btn-close-history">Close History</button>
+            </div>
+            <div class="timeline" id="history-timeline">
+                <div style="text-align:center; padding:2rem;">Loading history...</div>
+            </div>
+        `;
+
+    document.getElementById('btn-close-history')?.addEventListener('click', () => {
+      this.restoreMainView();
+    });
+
+    try {
+      const history = await this.profileModule.getHistory();
+      const container = document.getElementById('history-timeline');
+      if (!container) return;
+
+      if (history.length === 0) {
+        container.innerHTML = '<div style="text-align:center; padding:2rem;">No history found.</div>';
+        return;
+      }
+
+      container.innerHTML = history.map((entry, index) => `
+                <div class="timeline-item">
+                    <div class="timeline-marker"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-header">
+                            <h3 class="commit-msg">${entry.message}</h3>
+                            ${index > 0 ? `<button class="btn-rollback" data-id="${entry.commitId}">Rollback to this</button>` : '<span style="font-size:0.8rem; color:green; font-weight:bold;">Current Head</span>'}
+                        </div>
+                        <div class="commit-meta">
+                            <span>🕒 ${new Date(entry.timestamp).toLocaleString()}</span>
+                            <span>👤 ${entry.author || 'Unknown'}</span>
+                            <span>#${entry.commitId.slice(0, 8)}</span>
+                        </div>
+                    </div>
+                </div>
+            `).join('');
+
+      container.querySelectorAll('.btn-rollback').forEach(btn => {
+        btn.addEventListener('click', () => this.rollbackToCommit(btn.getAttribute('data-id')!));
+      });
+
+    } catch (e) {
+      main.innerHTML += `<div style="color:red; padding:1rem;">Failed to load history: ${e}</div>`;
+    }
+  }
+
+  private async rollbackToCommit(commitId: string) {
+    if (!confirm('Are you sure you want to rollback to this commit? Current unsaved changes will be lost.')) return;
+
+    try {
+      await this.profileModule.rollback(commitId, 'Admin Rollback');
+      alert('Rollback successful!');
+      this.updateStagedStatus();
+      this.renderCategories(); // refresh data
+      this.restoreMainView();
+    } catch (e) {
+      alert(`Rollback failed: ${e}`);
+    }
+  }
+
+  private restoreMainView() {
+    this.renderLayout(); // Re-render the full layout
+    this.updateStagedStatus(); // checks staged status again
+    // Note: renderLayout calls renderCategories, but we might lose 'selection'. That's fine.
+  }
+
+  // ============ ACTIONS ============ //
+
+  private updateStagedStatus() {
+    const changes = this.profileModule.getStagedChanges();
+    const badge = document.getElementById('staged-badge');
+    if (badge) {
+      badge.style.display = changes ? 'inline-block' : 'none';
+    }
+  }
+
+  private async handleCommit() {
+    const changes = this.profileModule.getStagedChanges();
+    if (!changes) {
+      alert('No changes to commit');
+      return;
+    }
+
+    const msg = prompt('Enter commit message:', 'Update menu');
+    if (!msg) return;
+
+    try {
+      await this.profileModule.commitChanges(msg, 'Admin');
+      this.updateStagedStatus();
+      alert('Changes committed successfully!');
+    } catch (e) {
+      alert(`Commit failed: ${e}`);
+    }
+  }
+
+  private handleExport() {
+    const json = this.profileModule.exportProfile();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `current.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  // ============ CATEGORY EDITOR ============ //
+
+  private addNewCategory() {
+    const name = prompt('New Category Name:');
+    if (!name) return;
+
+    this.profileModule.addCategory({
+      name,
+      displayOrder: this.profileModule.getCategories().length + 1,
+      commonOptionGroups: []
+    });
+    this.renderCategories();
+    this.updateStagedStatus();
+  }
+
+  private editCategory(id: string) {
+    const category = this.profileModule.getCategory(id);
+    if (!category) return;
+
+    const panel = document.getElementById('editor-panel');
+    if (!panel) return;
+
+    panel.innerHTML = `
+            <h3>Edit Category</h3>
+            <div class="form-group">
+                <label>Name</label>
+                <input type="text" class="form-control" id="cat-name" value="${category.name}">
+            </div>
+            <div class="form-group">
+                <label>Display Order</label>
+                <input type="number" class="form-control" id="cat-order" value="${category.displayOrder}">
+            </div>
+            
+            <hr>
+            <h4>Common Option Groups</h4>
+            <div id="cat-common-options"></div>
+            <button class="btn btn-sm btn-primary" id="btn-add-cat-opt">Add Group</button>
+
+            <div style="margin-top: 2rem; display:flex; gap:10px;">
+                <button class="btn btn-primary" id="btn-save-cat">Save</button>
+                <button class="btn btn-danger" id="btn-del-cat">Delete</button>
+                <button class="btn" onclick="document.getElementById('editor-panel').classList.remove('open')">Cancel</button>
+            </div>
+        `;
+
+    this.renderOptionGroupsEditor(category.commonOptionGroups || [], 'cat-common-options');
+
+    panel.classList.add('open');
+
+    // Save
+    document.getElementById('btn-save-cat')?.addEventListener('click', () => {
+      const name = (document.getElementById('cat-name') as HTMLInputElement).value;
+      const order = parseInt((document.getElementById('cat-order') as HTMLInputElement).value);
+      const options = this.collectOptionGroupsFromEditor('cat-common-options');
+
+      this.profileModule.updateCategory(id, {
+        name,
+        displayOrder: order,
+        commonOptionGroups: options
+      });
+
+      this.updateStagedStatus();
+      this.renderCategories();
+      this.closeEditor();
+      if (this.selectedCategoryId === id) this.renderItems();
+    });
+
+    // Delete
+    document.getElementById('btn-del-cat')?.addEventListener('click', () => {
+      if (confirm(`Delete category "${category.name}"?`)) {
+        this.profileModule.removeCategory(id);
+        this.updateStagedStatus();
+        this.selectedCategoryId = null;
+        this.renderCategories();
+        this.renderItems();
+        this.closeEditor();
+      }
+    });
+
+    // Add Option Group
+    document.getElementById('btn-add-cat-opt')?.addEventListener('click', () => {
+      this.addOptionGroupToEditor('cat-common-options');
+    });
+  }
+
+  // ============ ITEM EDITOR ============ //
+
+  private addNewItem() {
+    if (!this.selectedCategoryId) return;
+    this.profileModule.addMenuItem(this.selectedCategoryId, {
+      name: 'New Item',
+      price: 0,
+      description: '',
+      available: true,
+      optionGroups: []
+    });
+    this.renderItems();
+    this.updateStagedStatus();
+  }
+
+  private editItem(itemId: string) {
+    const item = this.profileModule.getMenuItem(itemId);
+    if (!item) return;
+
+    const panel = document.getElementById('editor-panel');
+    if (!panel) return;
+
+    // Highlight logic in list? Maybe later.
+
+    panel.innerHTML = `
+            <h3>Edit Item</h3>
+            <div class="form-group">
+                <label>Name</label>
+                <input type="text" class="form-control" id="item-name" value="${item.name}">
+            </div>
+            <div class="form-group">
+                <label>Price</label>
+                <input type="number" class="form-control" id="item-price" value="${item.price}">
+            </div>
+            <div class="form-group">
+                <label>Image URL</label>
+                <input type="text" class="form-control" id="item-img" value="${item.imgUrl || ''}">
+            </div>
+            <div class="form-group checkbox-group">
+                <input type="checkbox" id="item-avail" ${item.available ? 'checked' : ''}>
+                <label for="item-avail" style="margin:0">Available</label>
+            </div>
+
+            <hr>
+            <h4>Option Groups</h4>
+            <div id="item-options"></div>
+            <button class="btn btn-sm btn-primary" id="btn-add-item-opt">Add Group</button>
+
+            <div style="margin-top: 2rem; display:flex; gap:10px;">
+                <button class="btn btn-primary" id="btn-save-item">Save</button>
+                <button class="btn btn-danger" id="btn-del-item">Delete</button>
+            </div>
+        `;
+
+    this.renderOptionGroupsEditor(item.optionGroups || [], 'item-options');
+    panel.classList.add('open');
+
+    // Handlers
+    document.getElementById('btn-save-item')?.addEventListener('click', () => {
+      const name = (document.getElementById('item-name') as HTMLInputElement).value;
+      const price = parseInt((document.getElementById('item-price') as HTMLInputElement).value);
+      const imgUrl = (document.getElementById('item-img') as HTMLInputElement).value;
+      const available = (document.getElementById('item-avail') as HTMLInputElement).checked;
+      const options = this.collectOptionGroupsFromEditor('item-options');
+
+      this.profileModule.updateMenuItem(itemId, {
+        name, price, imgUrl, available, optionGroups: options
+      });
+
+      this.updateStagedStatus();
+      this.renderItems();
+      this.closeEditor();
+    });
+
+    document.getElementById('btn-del-item')?.addEventListener('click', () => {
+      if (confirm(`Delete item "${item.name}"?`)) {
+        this.profileModule.removeMenuItem(itemId);
+        this.updateStagedStatus();
+        this.renderItems();
+        this.closeEditor();
+      }
+    });
+
+    document.getElementById('btn-add-item-opt')?.addEventListener('click', () => {
+      this.addOptionGroupToEditor('item-options');
+    });
+  }
+
+  // ============ OPTION EDITOR HELPERS ============ //
+
+  private renderOptionGroupsEditor(groups: MenuOptionGroup[], containerId: string) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = '';
+
+    groups.forEach(group => {
+      this.createOptionGroupElement(group, container);
+    });
+  }
+
+  private createOptionGroupElement(group: MenuOptionGroup, container: HTMLElement) {
+    const div = document.createElement('div');
+    div.className = 'option-group-editor';
+    div.dataset.id = group.id;
+
+    div.innerHTML = `
+            <div style="display:flex; justify-content:space-between; margin-bottom:5px;">
+                <input type="text" class="form-control group-name" value="${group.name}" placeholder="Group Name" style="width:60%">
+                <button class="btn-sm btn-danger btn-del-group">✕</button>
+            </div>
+            <div style="display:flex; gap:10px; font-size:12px; margin-bottom:10px;">
+                <label><input type="checkbox" class="group-req" ${group.required ? 'checked' : ''}> Required</label>
+                <label><input type="checkbox" class="group-multi" ${group.multiSelect ? 'checked' : ''}> Multi</label>
+                <input type="number" class="form-control group-max" value="${group.maxSelections || ''}" placeholder="Max" style="width:50px; padding:2px;">
+            </div>
+            <div class="option-items-container">
+            </div>
+            <button class="btn-sm btn-add-opt-item" style="margin-top:5px;">+ Option</button>
+        `;
+
+    const itemsContainer = div.querySelector('.option-items-container') as HTMLElement;
+    group.items.forEach(item => this.createOptionItemElement(item, itemsContainer));
+
+    // Listeners for this group block
+    div.querySelector('.btn-del-group')?.addEventListener('click', () => div.remove());
+    div.querySelector('.btn-add-opt-item')?.addEventListener('click', () => {
+      this.createOptionItemElement({
+        id: uuidv4(),
+        name: 'New Option',
+        price: 0,
+        available: true,
+        imgUrl: ''
+      }, itemsContainer);
+    });
+
+    container.appendChild(div);
+  }
+
+  private createOptionItemElement(item: MenuOptionItem, container: HTMLElement) {
+    const startId = item.id;
+    const div = document.createElement('div');
+    div.className = 'option-item-row';
+    div.dataset.id = startId; // keep original ID if possible, mostly relevant for tracking
+
+    div.innerHTML = `
+            <input type="text" class="form-control item-name" value="${item.name}" placeholder="Opt Name" style="flex:2">
+            <input type="text" class="form-control item-img" value="${item.imgUrl || ''}" placeholder="Img URL" style="flex:2">
+            <input type="number" class="form-control item-price" value="${item.price}" placeholder="Price" style="flex:1">
+            <button class="btn-sm btn-danger btn-del-opt-item">✕</button>
+        `;
+
+    div.querySelector('.btn-del-opt-item')?.addEventListener('click', () => div.remove());
+    container.appendChild(div);
+  }
+
+  private addOptionGroupToEditor(containerId: string) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    this.createOptionGroupElement({
+      id: uuidv4(),
+      name: 'New Group',
+      required: false,
+      multiSelect: false,
+      items: []
+    }, container);
+  }
+
+  private collectOptionGroupsFromEditor(containerId: string): MenuOptionGroup[] {
+    const container = document.getElementById(containerId);
+    if (!container) return [];
+
+    const groups: MenuOptionGroup[] = [];
+    container.querySelectorAll('.option-group-editor').forEach((groupEl: any) => {
+      const id = groupEl.dataset.id || uuidv4();
+      const name = (groupEl.querySelector('.group-name') as HTMLInputElement).value;
+      const required = (groupEl.querySelector('.group-req') as HTMLInputElement).checked;
+      const multiSelect = (groupEl.querySelector('.group-multi') as HTMLInputElement).checked;
+      const maxVal = (groupEl.querySelector('.group-max') as HTMLInputElement).value;
+      const maxSelections = maxVal ? parseInt(maxVal) : undefined;
+
+      const items: MenuOptionItem[] = [];
+      groupEl.querySelectorAll('.option-item-row').forEach((itemEl: any) => {
+        // If it's a new item (no dataset.id or handled upstream), we generate ID.
+        // But createOptionItemElement assigns dataset.id.
+        // If the user modified the UI and it's a new element, it must have an ID.
+        // My createOptionItemElement logic generates ID for new ones.
+        const itemId = itemEl.dataset.id || uuidv4(); // fallback
+        items.push({
+          id: itemId,
+          name: (itemEl.querySelector('.item-name') as HTMLInputElement).value,
+          imgUrl: (itemEl.querySelector('.item-img') as HTMLInputElement).value,
+          price: parseInt((itemEl.querySelector('.item-price') as HTMLInputElement).value) || 0,
+          available: true // Default to true for editor simplicity for now
+        });
+      });
+
+      groups.push({
+        id,
+        name,
+        required,
+        multiSelect,
+        maxSelections,
+        items
+      });
+    });
+
+    return groups;
+  }
+}
+
+new AdminUI('app').init();

--- a/src/modules/auth/AuthManager.ts
+++ b/src/modules/auth/AuthManager.ts
@@ -1,0 +1,51 @@
+export class AuthManager {
+  // Default hashed password (sha256 hash of 'admin1234')
+  // In a real app, this should be stored securely on the server
+  private static DEFAULT_HASH = 'ac9689e2272427085e35b9d3e3e8bed88cb3434828b43b86fc0596cad4c6e270';
+  private static STORAGE_KEY = 'kiospeak_admin_auth';
+
+  static async authenticate(password: string): Promise<boolean> {
+    let storedHash = localStorage.getItem(this.STORAGE_KEY);
+    const inputHash = await this.hashPassword(password);
+
+    // If no key exists, check against default
+    if (!storedHash) {
+      if (inputHash === this.DEFAULT_HASH) {
+        // If it matches default, ensure we sync it to storage
+        localStorage.setItem(this.STORAGE_KEY, this.DEFAULT_HASH);
+        return true;
+      }
+      return false;
+    }
+
+    return storedHash === inputHash;
+  }
+
+  static async changePassword(currentPassword: string, newPassword: string): Promise<boolean> {
+    if (await this.authenticate(currentPassword)) {
+      const newHash = await this.hashPassword(newPassword);
+      localStorage.setItem(this.STORAGE_KEY, newHash);
+      return true;
+    }
+    return false;
+  }
+
+  static checkAuth(): boolean {
+    return sessionStorage.getItem('admin_authenticated') === 'true';
+  }
+
+  static login() {
+    sessionStorage.setItem('admin_authenticated', 'true');
+  }
+
+  static logout() {
+    sessionStorage.removeItem('admin_authenticated');
+  }
+
+  private static async hashPassword(password: string): Promise<string> {
+    const msgBuffer = new TextEncoder().encode(password);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+}

--- a/src/modules/core/CartManager.ts
+++ b/src/modules/core/CartManager.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
-import { StoreProfileModule, MenuItem, MenuOptionGroup } from '../store_profile';
+import { StoreProfileModule } from '../store_profile';
+import type { MenuOptionGroup } from '../store_profile';
 
 // ============ Types ============
 

--- a/src/modules/core/StoreProfileManager.ts
+++ b/src/modules/core/StoreProfileManager.ts
@@ -4,6 +4,7 @@ import type {
   StoreProfile,
   MenuCategory,
   MenuItem,
+  MenuOptionGroup,
   HistoryEntry
 } from '../store_profile/types';
 
@@ -49,6 +50,7 @@ export class StoreProfileManager {
     return this.module.getRawMenuItem(itemId);
   }
 
+
   // ============ Write Operations (Staging) ============
   public addCategory(category: Omit<MenuCategory, 'id' | 'items'>): string {
     return this.module.addCategory(category);
@@ -63,15 +65,88 @@ export class StoreProfileManager {
   }
 
   public addMenuItem(categoryId: string, item: Omit<MenuItem, 'id'>): string {
+    const categories = this.module.getCategories();
+    const category = categories.find((c) => c.id === categoryId);
+    if (!category) {
+      throw new Error(`Category not found: ${categoryId}`);
+    }
+
+    this.validateUniqueItemName(category, item.name);
+    this.validateUniqueOptionNames(item.optionGroups);
+
     return this.module.addMenuItem(categoryId, item);
   }
 
   public updateMenuItem(itemId: string, updates: Partial<MenuItem>): void {
+    if (updates.name || updates.optionGroups) {
+      const categories = this.module.getCategories();
+      let foundCategory: MenuCategory | undefined;
+
+      for (const cat of categories) {
+        const item = cat.items.find((i) => i.id === itemId);
+        if (item) {
+          foundCategory = cat;
+          break;
+        }
+      }
+
+      if (foundCategory) {
+        if (updates.name) {
+          this.validateUniqueItemName(foundCategory, updates.name, itemId);
+        }
+        if (updates.optionGroups) {
+          this.validateUniqueOptionNames(updates.optionGroups);
+        }
+      }
+    }
+
     this.module.updateMenuItem(itemId, updates);
   }
 
   public removeMenuItem(itemId: string): void {
     this.module.removeMenuItem(itemId);
+  }
+
+  // ============ Validation Helpers ============
+  private validateUniqueItemName(
+    category: MenuCategory,
+    name: string,
+    excludeId?: string
+  ): void {
+    const hasDuplicate = category.items.some(
+      (i) => i.name === name && i.id !== excludeId
+    );
+    if (hasDuplicate) {
+      throw new Error(
+        `Menu item with name "${name}" already exists in category "${category.name}"`
+      );
+    }
+  }
+
+  private validateUniqueOptionNames(
+    optionGroups: MenuOptionGroup[] | undefined
+  ): void {
+    if (!optionGroups) return;
+
+    // 1. Validate Option Group names are unique
+    const groupNames = new Set<string>();
+    for (const group of optionGroups) {
+      if (groupNames.has(group.name)) {
+        throw new Error(`Duplicate option group name: "${group.name}"`);
+      }
+      groupNames.add(group.name);
+
+      // 2. Validate Option Item names are unique within the group
+      const itemNames = new Set<string>();
+      for (const item of group.items) {
+        if (itemNames.has(item.name)) {
+          throw new Error(
+            `Duplicate option item name "${item.name}" in group "${group.name}"`
+          );
+        }
+        itemNames.add(item.name);
+      }
+    }
   }
 
   // ============ Commit / History Operations ============

--- a/src/modules/core/StoreProfileManager.ts
+++ b/src/modules/core/StoreProfileManager.ts
@@ -1,0 +1,101 @@
+
+import { StoreProfileModule } from '../store_profile';
+import type {
+  StoreProfile,
+  MenuCategory,
+  MenuItem,
+  HistoryEntry
+} from '../store_profile/types';
+
+export class StoreProfileManager {
+  private static instance: StoreProfileManager;
+  private module: StoreProfileModule;
+
+  private constructor() {
+    this.module = new StoreProfileModule();
+  }
+
+  public static getInstance(): StoreProfileManager {
+    if (!StoreProfileManager.instance) {
+      StoreProfileManager.instance = new StoreProfileManager();
+    }
+    return StoreProfileManager.instance;
+  }
+
+  public async initialize(): Promise<void> {
+    if (this.module.status !== 'ready') {
+      await this.module.initialize();
+    }
+  }
+
+  // ============ Read Operations ============
+  public getStoreInfo() {
+    return this.module.getStoreInfo();
+  }
+
+  public getCategories(): MenuCategory[] {
+    return this.module.getCategories();
+  }
+
+  public getCategory(categoryId: string): MenuCategory | undefined {
+    return this.module.getCategory(categoryId);
+  }
+
+  public getMenuItem(itemId: string): MenuItem | undefined {
+    return this.module.getMenuItem(itemId);
+  }
+
+  public getRawMenuItem(itemId: string): MenuItem | undefined {
+    return this.module.getRawMenuItem(itemId);
+  }
+
+  // ============ Write Operations (Staging) ============
+  public addCategory(category: Omit<MenuCategory, 'id' | 'items'>): string {
+    return this.module.addCategory(category);
+  }
+
+  public updateCategory(categoryId: string, updates: Partial<Omit<MenuCategory, 'id' | 'items'>>): void {
+    this.module.updateCategory(categoryId, updates);
+  }
+
+  public removeCategory(categoryId: string): void {
+    this.module.removeCategory(categoryId);
+  }
+
+  public addMenuItem(categoryId: string, item: Omit<MenuItem, 'id'>): string {
+    return this.module.addMenuItem(categoryId, item);
+  }
+
+  public updateMenuItem(itemId: string, updates: Partial<MenuItem>): void {
+    this.module.updateMenuItem(itemId, updates);
+  }
+
+  public removeMenuItem(itemId: string): void {
+    this.module.removeMenuItem(itemId);
+  }
+
+  // ============ Commit / History Operations ============
+  public getStagedChanges(): Partial<StoreProfile> | null {
+    return this.module.getStagedChanges();
+  }
+
+  public async commitChanges(message: string, author?: string): Promise<void> {
+    await this.module.commitChanges(message, author);
+  }
+
+  public async getHistory(limit?: number): Promise<HistoryEntry[]> {
+    return this.module.getHistory(limit);
+  }
+
+  public async rollback(commitId: string, author?: string): Promise<void> {
+    await this.module.rollback(commitId, author);
+  }
+
+  public importProfile(json: string): void {
+    this.module.importProfile(json);
+  }
+
+  public exportProfile(): string {
+    return this.module.exportProfile();
+  }
+}

--- a/src/modules/store_profile/StoreProfileModule.ts
+++ b/src/modules/store_profile/StoreProfileModule.ts
@@ -397,6 +397,9 @@ export class StoreProfileModule {
       throw new Error(`Category not found: ${categoryId}`);
     }
 
+    const category = menu.categories[categoryIndex];
+    this.validateUniqueItemName(category, item.name);
+
     const newItem: MenuItem = {
       ...item,
       id: uuidv4(),
@@ -425,6 +428,12 @@ export class StoreProfileModule {
       if (itemIndex === -1) return category;
 
       found = true;
+
+      // If name is being updated, check for duplicates
+      if (updates.name) {
+        this.validateUniqueItemName(category, updates.name, itemId);
+      }
+
       const newItems = [...category.items];
       newItems[itemIndex] = { ...newItems[itemIndex], ...updates };
       return { ...category, items: newItems };
@@ -659,9 +668,16 @@ export class StoreProfileModule {
   getPaymentSettings(): PaymentSettings | undefined {
     return this.getSettings().payment;
   }
-
   getDisplaySettings(): DisplaySettings | undefined {
     return this.getSettings().display;
+  }
+
+  // ============ Helper Methods ============
+  private validateUniqueItemName(category: MenuCategory, name: string, excludeId?: string): void {
+    const hasDuplicate = category.items.some(i => i.name === name && i.id !== excludeId);
+    if (hasDuplicate) {
+      throw new Error(`Menu item with name "${name}" already exists in category "${category.name}"`);
+    }
   }
 
   // ============ Export/Import ============

--- a/src/modules/store_profile/StoreProfileModule.ts
+++ b/src/modules/store_profile/StoreProfileModule.ts
@@ -361,15 +361,28 @@ export class StoreProfileModule {
     };
   }
 
-  /**
-   * 메뉴 이름으로 메뉴 아이템 조회
-   */
   getMenuItemByName(name: string): MenuItem | undefined {
     this.ensureReady();
     for (const category of this.getWorkingProfile().menu.categories) {
       const item = category.items.find((i) => i.name === name);
       if (item) {
         return this.resolveItem(item, category);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get raw menu item (without resolving common option groups)
+   * Used for editing to prevent baking common options into item-specific options
+   */
+  getRawMenuItem(itemId: string): MenuItem | undefined {
+    this.ensureReady();
+    for (const category of this.getWorkingProfile().menu.categories) {
+      const item = category.items.find((i) => i.id === itemId);
+      if (item) {
+        // Return a copy to prevent direct mutation of internal state
+        return { ...item };
       }
     }
     return undefined;

--- a/src/modules/store_profile/StoreProfileModule.ts
+++ b/src/modules/store_profile/StoreProfileModule.ts
@@ -412,6 +412,7 @@ export class StoreProfileModule {
 
     const category = menu.categories[categoryIndex];
     this.validateUniqueItemName(category, item.name);
+    this.validateUniqueOptionNames(item.optionGroups);
 
     const newItem: MenuItem = {
       ...item,
@@ -445,6 +446,10 @@ export class StoreProfileModule {
       // If name is being updated, check for duplicates
       if (updates.name) {
         this.validateUniqueItemName(category, updates.name, itemId);
+      }
+      // If optionGroups are being updated, check for duplicates
+      if (updates.optionGroups) {
+        this.validateUniqueOptionNames(updates.optionGroups);
       }
 
       const newItems = [...category.items];
@@ -690,6 +695,28 @@ export class StoreProfileModule {
     const hasDuplicate = category.items.some(i => i.name === name && i.id !== excludeId);
     if (hasDuplicate) {
       throw new Error(`Menu item with name "${name}" already exists in category "${category.name}"`);
+    }
+  }
+
+  private validateUniqueOptionNames(optionGroups: MenuOptionGroup[] | undefined): void {
+    if (!optionGroups) return;
+
+    // 1. Validate Option Group names are unique
+    const groupNames = new Set<string>();
+    for (const group of optionGroups) {
+      if (groupNames.has(group.name)) {
+        throw new Error(`Duplicate option group name: "${group.name}"`);
+      }
+      groupNames.add(group.name);
+
+      // 2. Validate Option Item names are unique within the group
+      const itemNames = new Set<string>();
+      for (const item of group.items) {
+        if (itemNames.has(item.name)) {
+          throw new Error(`Duplicate option item name "${item.name}" in group "${group.name}"`);
+        }
+        itemNames.add(item.name);
+      }
     }
   }
 

--- a/src/modules/store_profile/StoreProfileModule.ts
+++ b/src/modules/store_profile/StoreProfileModule.ts
@@ -410,9 +410,6 @@ export class StoreProfileModule {
       throw new Error(`Category not found: ${categoryId}`);
     }
 
-    const category = menu.categories[categoryIndex];
-    this.validateUniqueItemName(category, item.name);
-    this.validateUniqueOptionNames(item.optionGroups);
 
     const newItem: MenuItem = {
       ...item,
@@ -442,15 +439,6 @@ export class StoreProfileModule {
       if (itemIndex === -1) return category;
 
       found = true;
-
-      // If name is being updated, check for duplicates
-      if (updates.name) {
-        this.validateUniqueItemName(category, updates.name, itemId);
-      }
-      // If optionGroups are being updated, check for duplicates
-      if (updates.optionGroups) {
-        this.validateUniqueOptionNames(updates.optionGroups);
-      }
 
       const newItems = [...category.items];
       newItems[itemIndex] = { ...newItems[itemIndex], ...updates };
@@ -691,34 +679,6 @@ export class StoreProfileModule {
   }
 
   // ============ Helper Methods ============
-  private validateUniqueItemName(category: MenuCategory, name: string, excludeId?: string): void {
-    const hasDuplicate = category.items.some(i => i.name === name && i.id !== excludeId);
-    if (hasDuplicate) {
-      throw new Error(`Menu item with name "${name}" already exists in category "${category.name}"`);
-    }
-  }
-
-  private validateUniqueOptionNames(optionGroups: MenuOptionGroup[] | undefined): void {
-    if (!optionGroups) return;
-
-    // 1. Validate Option Group names are unique
-    const groupNames = new Set<string>();
-    for (const group of optionGroups) {
-      if (groupNames.has(group.name)) {
-        throw new Error(`Duplicate option group name: "${group.name}"`);
-      }
-      groupNames.add(group.name);
-
-      // 2. Validate Option Item names are unique within the group
-      const itemNames = new Set<string>();
-      for (const item of group.items) {
-        if (itemNames.has(item.name)) {
-          throw new Error(`Duplicate option item name "${item.name}" in group "${group.name}"`);
-        }
-        itemNames.add(item.name);
-      }
-    }
-  }
 
   // ============ Export/Import ============
 

--- a/src/modules/store_profile/types.ts
+++ b/src/modules/store_profile/types.ts
@@ -66,6 +66,9 @@ export interface MenuItem {
   available: boolean;
   tags?: string[];
   optionGroups?: MenuOptionGroup[]; // 아이템별 옵션 그룹
+
+  // Advanced Option Control
+  excludeOptions?: string[]; // IDs of option items to exclude (from common groups)
 }
 
 export interface MenuCategory {

--- a/src/modules/store_profile/validators/ProfileValidator.test.ts
+++ b/src/modules/store_profile/validators/ProfileValidator.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProfileValidator } from './ProfileValidator';
+import type { StoreProfile } from '../types';
+
+describe('ProfileValidator - excludeOptions', () => {
+  let validator: ProfileValidator;
+  let validProfile: StoreProfile;
+
+  beforeEach(() => {
+    validator = new ProfileValidator();
+    // Create a minimal valid profile structure for testing
+    validProfile = {
+      profileId: 'test-profile',
+      version: '1.0.0',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      store: {
+        id: 'store-1',
+        name: 'Test Store',
+        currency: 'KRW'
+      },
+      menu: {
+        categories: [
+          {
+            id: 'cat-1',
+            name: 'Category 1',
+            displayOrder: 1,
+            commonOptionGroups: [
+              {
+                id: 'group1',
+                name: 'Group 1',
+                required: false,
+                multiSelect: false,
+                items: [
+                  { id: 'opt1', name: 'Option 1', price: 0, available: true },
+                  { id: 'opt2', name: 'Option 2', price: 0, available: true }
+                ]
+              }
+            ],
+            items: [
+              {
+                id: 'item-1',
+                name: 'Item 1',
+                price: 1000,
+                available: true,
+                // Valid excludeOptions references
+                excludeOptions: ['opt1', 'group1.opt2']
+              }
+            ]
+          }
+        ]
+      },
+      promotions: [],
+      settings: {
+        language: 'ko',
+        voiceAssistant: { enabled: true, greeting: 'Hi', persona: 'friendly' },
+        payment: { acceptedMethods: ['card'], tipEnabled: false },
+        display: { theme: 'light', fontSize: 'medium', idleTimeout: 15 },
+        ageRestrictions: { enabled: false, restrictedItems: [], minAge: 19 }
+      }
+    };
+  });
+
+  it('should validate a profile with valid excludeOptions string array', () => {
+    const isValid = validator.validate(validProfile);
+    expect(isValid).toBe(true);
+    expect(validator.getErrors()).toHaveLength(0);
+  });
+
+  it('should validate valid excludeOptions references', () => {
+    const profile = JSON.parse(JSON.stringify(validProfile));
+    // Valid references:
+    // 'opt1' exists
+    // 'group1.opt2' (mock scenario)
+
+    // Let's make sure the structure supports the test
+    const category = profile.menu.categories[0];
+    category.commonOptionGroups = [
+      {
+        id: 'common_group',
+        name: 'Common Group',
+        required: false,
+        multiSelect: false,
+        items: [
+          { id: 'common_opt_1', name: 'Opt 1', price: 0, available: true },
+          { id: 'common_opt_2', name: 'Opt 2', price: 0, available: true }
+        ]
+      }
+    ];
+    category.items[0].optionGroups = [
+      {
+        id: 'item_group',
+        name: 'Item Group',
+        required: false,
+        multiSelect: false,
+        items: [
+          { id: 'item_opt_1', name: 'Item Opt 1', price: 0, available: true }
+        ]
+      }
+    ];
+
+    // Valid: exclude common group ID
+    category.items[0].excludeOptions = ['common_group'];
+    expect(validator.validate(profile)).toBe(true);
+
+    // Valid: exclude common option ID
+    category.items[0].excludeOptions = ['common_opt_1'];
+    expect(validator.validate(profile)).toBe(true);
+
+    // Valid: exclude specific common option (groupId.optionId)
+    category.items[0].excludeOptions = ['common_group.common_opt_2'];
+    expect(validator.validate(profile)).toBe(true);
+
+    // Valid: exclude item group specific option (though redundant, it is valid reference)
+    category.items[0].excludeOptions = ['item_opt_1'];
+    expect(validator.validate(profile)).toBe(true);
+  });
+
+  it('should fail if excludeOptions contains non-existent references', () => {
+    const profile = JSON.parse(JSON.stringify(validProfile));
+    const category = profile.menu.categories[0];
+    category.commonOptionGroups = [{ id: 'g1', name: 'G1', required: false, multiSelect: false, items: [{ id: 'o1', name: 'O1', price: 0, available: true }] }];
+
+    // Invalid: ID does not exist
+    category.items[0].excludeOptions = ['non_existent_id'];
+
+    const isValid = validator.validate(profile);
+    expect(isValid).toBe(false);
+    expect(validator.getErrorMessages()).toContain('menu.categories[0].items[0].excludeOptions[0]: Reference "non_existent_id" not found in option groups');
+  });
+
+  it('should fail if excludeOptions is not an array', () => {
+    const invalidProfile = JSON.parse(JSON.stringify(validProfile));
+    // @ts-ignore - testing invalid type
+    invalidProfile.menu.categories[0].items[0].excludeOptions = "not-an-array";
+
+    const isValid = validator.validate(invalidProfile);
+    expect(isValid).toBe(false);
+    expect(validator.getErrorMessages()).toContain('menu.categories[0].items[0].excludeOptions: Must be an array');
+  });
+
+  it('should fail if excludeOptions contains non-string items', () => {
+    const invalidProfile = JSON.parse(JSON.stringify(validProfile));
+    // @ts-ignore - testing invalid content
+    invalidProfile.menu.categories[0].items[0].excludeOptions = ['valid_opt', 123];
+
+    const isValid = validator.validate(invalidProfile);
+    expect(isValid).toBe(false);
+    expect(validator.getErrorMessages()).toContain('menu.categories[0].items[0].excludeOptions[1]: Must be a string');
+  });
+});

--- a/src/modules/vision/AgeDetector.ts
+++ b/src/modules/vision/AgeDetector.ts
@@ -84,7 +84,7 @@ export class AgeDetector {
     try {
       // Detect face with age and gender
       const detection = await faceapi
-        .detectSingleFace(input, new faceapi.TinyFaceDetectorOptions())
+        .detectSingleFace(input as any, new faceapi.TinyFaceDetectorOptions())
         .withFaceLandmarks()
         .withAgeAndGender();
 

--- a/src/test-integration.ts
+++ b/src/test-integration.ts
@@ -201,7 +201,7 @@ async function main() {
   };
 
   // Setup Gemini Events
-  geminiClient.on('log', (msg) => {
+  geminiClient.on('log', (_msg) => {
     // Filter out raw logs if needed
   });
 

--- a/src/ui/KioskUI.ts
+++ b/src/ui/KioskUI.ts
@@ -40,7 +40,8 @@ export class KioskUI {
     // Layout Structure
     this.container.innerHTML = `
             <div class="kiosk-container">
-                <header class="kiosk-header">
+                <header class="kiosk-header" style="position: relative;">
+                    <div id="admin-trigger" style="position: absolute; top: 0; left: 0; width: 20px; height: 20px; cursor: pointer; z-index: 1000;" title="Admin"></div>
                     <div class="brand-logo">🍔 KioSpeak</div>
                 </header>
                 
@@ -127,6 +128,11 @@ export class KioskUI {
 
     // Clear Cart Listener
     document.getElementById('clear-cart')?.addEventListener('click', () => this.clearCart());
+
+    // Admin Trigger
+    document.getElementById('admin-trigger')?.addEventListener('click', () => {
+      window.location.href = '/admin.html';
+    });
 
     // Initial Render
     this.renderCategories();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     open: true,
   },
   build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        admin: resolve(__dirname, 'admin.html'),
+      },
+    },
     outDir: 'dist',
     sourcemap: true,
   },


### PR DESCRIPTION
## 주요 todo
KioSpeak 메뉴 프로필 관리 전용 Admin UI와 메뉴 옵션 제외 기능 추가. Admin 진입 트리거, 검증/테스트 포함.
운영 환경에서만 편집 허용. 로컬 체험은 npm run build → npm run preview로 확인.

## 세부 todo
### Admin 전용 페이지 추가
admin.html + src/admin.ts: 로그인(기본 비번 admin1234, src/modules/auth/AuthManager.ts), 비번 변경, 카테고리/아이템 CRUD, 공통 옵션 편집, 옵션 제외(exclude) 선택, 커밋/히스토리/롤백, JSON import/export.
Kiosk 화면(src/ui/KioskUI.ts)에 숨김 영역 클릭 시 Admin으로 이동하는 트리거 배치(헤더 좌상단 20px 영역).

트리거 위치
<img width="1208" height="786" alt="image" src="https://github.com/user-attachments/assets/750b0eab-cf61-4a9b-b088-96a7aef7130f" />

### StoreProfileManager 생성
StoreProfileManager를 추가해 프로필 로드/커밋/롤백/검증 흐름을 캡슐화하고, Admin UI와 Kiosk 양쪽에서 동일하게 사용.
이를 추가해 sequence diagram 충족

### 프로필 스키마/모듈 확장
src/modules/store_profile/types.ts에 excludeOptions 필드 추가. 중복 이름 검증/getRawMenuItem 등 편의 메서드 추가. 
새 샘플 프로필public/profile/coffee_profile.json에서 exclude 옵션 사용 사례 제공.
excludeOptions는 commonOptions option값들만 들어올 수 있음

```js
          {
            "id": "americano",
            "name": "아메리카노",
            "price": 5000,
            "imgUrl": "https://img.lotteeatz.com/upload/product/2025/03/12/20250312105716967_0.png",
            "available": true,
            "optionGroups": [
              {
                "id": "water-amount",
                "name": "물 양 선택",
                "required": false,
                "multiSelect": false,
                "items": [
                  {
                    "id": "less-water",
                    "name": "물 적게",
                    "price": 0,
                    "available": true
                  },
                  {
                    "id": "more-water",
                    "name": "물 많이",
                    "price": 0,
                    "available": true
                  }
                ]
              }
            ],
            "excludeOptions": [
              "milk-amount",
              "shot-add.oat-milk",
              "shot-add.whipped-cream"
            ]
          },
```
### 검증 및 테스트
ProfileValidator가 공통 옵션 컨텍스트까지 받아 excludeOptions 참조를 검사하도록 강화하고(src/modules/store_profile/validators/ProfileValidator.ts), 유효/무효 케이스 커버하는 Vitest 추가(ProfileValidator.test.ts).

### 빌드/의존성
Vite 멀티 입력으로 admin 빌드 포함(vite.config.ts), package.json에 crypto-js 및 타입 추가(패스워드 해시에 대비). 타입 경고/린트 수정(AgeDetector, CartManager, test-integration).
`npm run install` 필요

### 새 데이터
커피 메뉴 프로필(public/profile/coffee_profile.json)에 원두/사이즈 등 옵션 세트와 메뉴별 exclude 예시(에스프레소는 사이즈/온도/샷 제외 등) 제공.
<img width="1457" height="926" alt="image" src="https://github.com/user-attachments/assets/96725835-210a-4f53-8314-46b0c0eb5c19" />
